### PR TITLE
Add tqdm progress bars to update command

### DIFF
--- a/src/west/app/project.py
+++ b/src/west/app/project.py
@@ -20,6 +20,8 @@ from pathlib import Path, PurePath
 from time import perf_counter
 from urllib.parse import urlparse
 
+from tqdm import tqdm
+
 from west import util
 from west.commands import CommandError, Verbosity, WestCommand
 from west.configuration import Configuration
@@ -1192,14 +1194,15 @@ class Update(_ProjectCommand):
             import_flags=ImportFlag.FORCE_PROJECTS)
 
         failed = []
-        for project in self.manifest.projects:
-            if (isinstance(project, ManifestProject) or
-                    project.name in self.updated):
+        projects = [p for p in self.manifest.projects
+                    if not isinstance(p, ManifestProject) and
+                    p.name not in self.updated]
+        for project in tqdm(projects, desc='west update', unit='proj',
+                            file=sys.stderr, disable=False):
+            if not self.project_is_active(project):
+                self.dbg(f'{project.name}: skipping inactive project')
                 continue
             try:
-                if not self.project_is_active(project):
-                    self.dbg(f'{project.name}: skipping inactive project')
-                    continue
                 self.update(project)
                 self.updated.add(project.name)
             except subprocess.CalledProcessError:
@@ -1264,9 +1267,9 @@ class Update(_ProjectCommand):
             projects = self._projects(self.args.projects)
 
         failed = []
-        for project in projects:
-            if isinstance(project, ManifestProject):
-                continue
+        iterable = [p for p in projects if not isinstance(p, ManifestProject)]
+        for project in tqdm(iterable, desc='west update', unit='proj',
+                            file=sys.stderr, disable=False):
             try:
                 self.update(project)
             except subprocess.CalledProcessError:

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -673,6 +673,10 @@ def test_update_projects(west_init_tmpdir):
     assert ur.kl_head_0 != ur.kl_head_1, 'failed updating kconfiglib HEAD'
     assert ur.tr_head_0 == ur.tr_head_1, 'tagged_repo HEAD changed'
 
+def test_update_progress_bar(west_init_tmpdir):
+    output = cmd('update', cwd=str(west_init_tmpdir), stderr=subprocess.STDOUT)
+    assert 'west update:' in output
+
 def test_update_projects_local_branch_commits(west_init_tmpdir):
     # Test the 'west update' command when working on local branch with local
     # commits and then updating project to upstream commit.


### PR DESCRIPTION
## Summary
- show git progress using tqdm in `west update`
- cover tqdm behavior with regression test

## Testing
- `python -m flake8 --config=tox.ini .`
- `python -m ruff check .`
- `python -m mypy --config-file=tox.ini --package=west`
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6868e20d1fb88321882bfda150b9a5ba